### PR TITLE
Fix image references in chart

### DIFF
--- a/deploy/helm-chart/Chart.yaml
+++ b/deploy/helm-chart/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "2.2.3"

--- a/deploy/helm-chart/templates/controller-driver.yaml
+++ b/deploy/helm-chart/templates/controller-driver.yaml
@@ -200,7 +200,7 @@ spec:
         # csi-provisioner: sidecar container that watches Kubernetes PersistentVolumeClaim objects
         # and triggers CreateVolume/DeleteVolume against a CSI endpoint
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.0.0
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
@@ -212,7 +212,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.5.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v3.5.0
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -225,7 +225,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
           args:
             - "--csi-address=$(ADDRESS)"
           env:

--- a/deploy/helm-chart/templates/node-driver.yaml
+++ b/deploy/helm-chart/templates/node-driver.yaml
@@ -59,7 +59,7 @@ spec:
         # 1) registers the CSI driver with kubelet
         # 2) adds the drivers custom NodeId to a label on the Kubernetes Node API Object
         - name: driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.0.0
           imagePullPolicy: IfNotPresent
           args:
             - --v=3

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -10,8 +10,7 @@ replicaCount: 1
 image:
   repository: "quay.io/ddn/exascaler-csi-file-driver"
   pullPolicy: "Always"
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: "v2.2.1"
+  tag: "v2.2.3"
 
 resources:
   limits:

--- a/deploy/kubernetes/exascaler-csi-file-driver.yaml
+++ b/deploy/kubernetes/exascaler-csi-file-driver.yaml
@@ -253,7 +253,7 @@ spec:
             capabilities:
               add: ['SYS_ADMIN']
             allowPrivilegeEscalation: true
-          image: quay.io/ddn/exascaler-csi-file-driver:v2.2.2
+          image: quay.io/ddn/exascaler-csi-file-driver:v2.2.3
           imagePullPolicy: IfNotPresent
           args:
             - --nodeid=$(KUBE_NODE_NAME)
@@ -371,7 +371,7 @@ spec:
             capabilities:
               add: ['SYS_ADMIN']
             allowPrivilegeEscalation: true
-          image: quay.io/ddn/exascaler-csi-file-driver:v2.2.2
+          image: quay.io/ddn/exascaler-csi-file-driver:v2.2.3
           imagePullPolicy: IfNotPresent
           args:
             - --nodeid=$(KUBE_NODE_NAME)

--- a/deploy/kubernetes/exascaler-csi-file-driver.yaml
+++ b/deploy/kubernetes/exascaler-csi-file-driver.yaml
@@ -212,7 +212,7 @@ spec:
         # csi-provisioner: sidecar container that watches Kubernetes PersistentVolumeClaim objects
         # and triggers CreateVolume/DeleteVolume against a CSI endpoint
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.0.0
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
@@ -224,7 +224,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.5.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v3.5.0
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -237,7 +237,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
           args:
             - "--csi-address=$(ADDRESS)"
           env:
@@ -349,7 +349,7 @@ spec:
         # 1) registers the CSI driver with kubelet
         # 2) adds the drivers custom NodeId to a label on the Kubernetes Node API Object
         - name: driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.0.0
           imagePullPolicy: IfNotPresent
           args:
             - --v=3

--- a/deploy/openshift/exascaler-csi-file-driver.yaml
+++ b/deploy/openshift/exascaler-csi-file-driver.yaml
@@ -290,7 +290,7 @@ spec:
         volumeMounts:
           - name: socket-dir
             mountPath: /csi/
-      - image: quay.io/ddn/exascaler-csi-file-driver:v2.2.2
+      - image: quay.io/ddn/exascaler-csi-file-driver:v2.2.3
         imagePullPolicy: Always
         args:
           - --nodeid=$(KUBE_NODE_NAME)
@@ -374,7 +374,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: quay.io/ddn/exascaler-csi-file-driver:v2.2.2
+          image: quay.io/ddn/exascaler-csi-file-driver:v2.2.3
           imagePullPolicy: Always
           args:
             - --nodeid=$(KUBE_NODE_NAME)

--- a/deploy/openshift/exascaler-csi-file-driver.yaml
+++ b/deploy/openshift/exascaler-csi-file-driver.yaml
@@ -280,7 +280,7 @@ spec:
           - name: socket-dir
             mountPath: /csi/
       - name: csi-resizer
-        image: k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
+        image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
         args:
           - "--csi-address=$(ADDRESS)"
         env:


### PR DESCRIPTION
The chart was using images from the deprecated k8s.gc.io repo.  I was also using a really old node-registrar that was not even a v2 docker style image.  This should bring the chart on parity with the other deployment methods