### PR TITLE
fix exascaler-csi-controller CrashLoopBackOff

### DIFF
--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -21,6 +21,7 @@ provisioner:
   repository: registry.k8s.io/sig-storage/csi-provisioner
   tag: v4.0.1
   pullPolicy: IfNotPresent
+  timeout: 120m
   resources:
 
 attacher:


### PR DESCRIPTION
Currently, deploying directly through Helm is unsuccessful, resulting in the pod consistently being in a CrashLoopBackOff state. I have fixed the issue with the exascaler-csi-controller repeatedly crashing.